### PR TITLE
fix: enforce post

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -123,6 +123,7 @@ function istanbulPlugin(opts?: IstanbulPluginOptions): Plugin {
     name: 'vite:istanbul',
     transform: createTransform(opts),
     configureServer: createConfigureServer(),
+    enforce: 'post'
   };
 }
 


### PR DESCRIPTION
For typescript users and other users that use such preprocessors, there is problem that babel could not parse the file.
I've added the enforce post to run the instrument at the end.